### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
-[![Stories in Ready](https://badge.waffle.io/ubuntudesign/snappy-squad-tasks.png?label=ready&title=Ready)](https://waffle.io/ubuntudesign/snappy-squad-tasks)
 # snappy-squad-tasks
+
+[![Stories in Ready](https://badge.waffle.io/ubuntudesign/snappy-squad-tasks.png?label=ready&title=Ready)](https://waffle.io/ubuntudesign/snappy-squad-tasks)
+
 A place to manage upcoming work for the Webteam's Snappy Squad.
 
 Tasks are tracked as issues, and can be viewed on the [Waffle board](https://waffle.io/ubuntudesign/snappy-squad-tasks).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/ubuntudesign/snappy-squad-tasks.png?label=ready&title=Ready)](https://waffle.io/ubuntudesign/snappy-squad-tasks)
 # snappy-squad-tasks
 A place to manage upcoming work for the Webteam's Snappy Squad.
 


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/ubuntudesign/snappy-squad-tasks

This was requested by a real person (user nottrobin) on waffle.io, we're not trying to spam you.